### PR TITLE
cmap() can be called on array-like

### DIFF
--- a/handout-tips.tex
+++ b/handout-tips.tex
@@ -126,7 +126,7 @@ You can use colormap to pick from a range of continuous colors.
 \begin{lstlisting}[belowskip=-\baselineskip]
  X = np.random.randn(1000, 4)
  cmap = plt.get_cmap("Oranges")
- colors = [cmap(i) for in in [.2,.4,.6,.8]]
+ colors = cmap([0.2, 0.4, 0.6, 0.8])
  
  ax.hist(X, 2, histtype='bar', color=colors)
 \end{lstlisting} &


### PR DESCRIPTION
No need for a list comprehension; just call `cmap(list)`.

Also, use `Oranges` colormap instead of `Blues` because the illustrative image is in orange and using `Blues` is slightly confusing then.