### PR TITLE
Fix issue #24 legend placement

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -921,20 +921,20 @@
                        p{0.33\columnwidth}
                        p{0.33\columnwidth}@{}}
       \scriptsize \rule{0pt}{1.25em}\noindent
-      1: lower left & 2: lower center & 3: lower right\\
-      4: left       & 5: center       & 6: right\\
-      7: upper left & 8: upper center & 9: upper right\\
+      1: lower left  & 2: lower center & 3: lower right\\
+      4: center left & 5: center       & 6: center right\\
+      7: upper left  & 8: upper center & 9: upper right\\
     \end{tabular}
 
     \begin{tabular}{@{}p{0.495\columnwidth}
                        p{0.495\columnwidth}@{}}
       \scriptsize \rule{0pt}{1.25em}\noindent
-      A: upper right / (-.1,.9) & B: right / (-.1,.5)\\
-      C: lower right / (-.1,.1) & D: upper left / (-.1,-.1)\\
-      E: upper center / (.5,-.1) & F: upper right / (.9,-.1)\\
-      G: lower left / (1.1,.1) & H: left / (1.1,.5)\\
-      I: upper left / (1.1,.9) & J: lower right / (.9,1.1)\\
-      K: lower center / (.5,1.1) & L: lower left / (.1,1.1)
+      A: upper right /  {\ttfamily (-.1,.9)} & B: center right / {\ttfamily (-.1,.5)}\\
+      C: lower right /  {\ttfamily (-.1,.1)} & D: upper left /   {\ttfamily (.1,-.1)}\\
+      E: upper center / {\ttfamily (.5,-.1)} & F: upper right /  {\ttfamily (.9,-.1)}\\
+      G: lower left /   {\ttfamily (1.1,.1)} & H: center left /  {\ttfamily (1.1,.5)}\\
+      I: upper left /   {\ttfamily (1.1,.9)} & J: lower right /  {\ttfamily (.9,1.1)}\\
+      K: lower center / {\ttfamily (.5,1.1)} & L: lower left /   {\ttfamily (.1,1.1)}
     \end{tabular}  
   \end{myboxed}
   %


### PR DESCRIPTION
Use 'center left' and 'center right' for backwards compatibility.
Correct x value for D case.