### PR TITLE
Fix scatter "marker" argument name

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -351,7 +351,7 @@
         \mandatory{Y},
         \optional{[s]izes},
         \optional{[c]olors},
-        \optional{markers},
+        \optional{marker},
         \optional{cmap}}
        {}
   \plot{basic-bar.pdf}{\textbf{bar[h]}(x,height,…)}


### PR DESCRIPTION
When calling `scatter`, the correct argument name for setting marker style is `marker` rather than `markers` (cf. [matplotlib.pyplot.scatter](https://matplotlib.org/3.2.0/api/_as_gen/matplotlib.pyplot.scatter.html)). 

This PR fixes this.