### PR TITLE
add GitHub Pages site with the latest cheatsheets and handouts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,7 +41,12 @@ jobs:
             texlive-xetex
       - name: Build artifacts
         run: |
+          # adjust the ImageMagick policies to convert PDF to PNG
+          # remove all policies restricting Ghostscript ability to process files
+          # https://stackoverflow.com/q/52998331
+          # https://stackoverflow.com/a/59193253
           sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
+          #
           make -C fonts/
           cp -r fonts/ /usr/share/fonts/
           fc-cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -21,6 +21,7 @@ jobs:
           sudo apt update
           sudo apt install \
             fontconfig    \
+            imagemagick   \
             libgeos++-dev \
             libproj-dev   \
             poppler-utils
@@ -40,7 +41,7 @@ jobs:
             texlive-xetex
       - name: Build artifacts
         run: |
-          rm *.pdf
+          sudo sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
           make -C fonts/
           cp -r fonts/ /usr/share/fonts/
           fc-cache
@@ -59,3 +60,10 @@ jobs:
           path: |
             cheatsheets.pdf
             handout-*.pdf
+      - name: Publish cheatsheets and handouts
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
+# TeX auxiliary files
+# ----------------------------------
 *.aux
 *.log
 *.out
 *.upa
+
+# generated figures
+# ----------------------------------
 figures/*.pdf
 fonts/**/*.[ot]tf

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ default: all
 
 .PHONY: all
 all: logos figures cheatsheets handouts
+	mkdir -p ./build/
+	cp cheatsheets*.p* ./build/
+	cp handout-*.p* ./build/
 
 .PHONY: logos
 logos:
@@ -22,12 +25,16 @@ figures:
 .PHONY: cheatsheets
 cheatsheets:
 	xelatex cheatsheets.tex
+	convert -density 150 cheatsheets.pdf -scene 1 cheatsheets.png
 
 .PHONY: handouts
 handouts:
 	xelatex handout-beginner.tex
 	xelatex handout-intermediate.tex
 	xelatex handout-tips.tex
+	convert -density 150 handout-tips.pdf handout-tips.png
+	convert -density 150 handout-beginner.pdf handout-beginner.png
+	convert -density 150 handout-intermediate.pdf handout-intermediate.png
 
 .PHONY: fonts
 fonts:
@@ -35,10 +42,14 @@ fonts:
 
 .PHONY: clean
 clean: $(SRC)
+	latexmk -c $^
+	- rm -rf ./build/
+
+.PHONY: clean-all
+clean-all: clean
 	- rm ./logos/mpl-logo2.pdf
 	git clean -f -X ./figures/
 	git clean -f ./scripts/*.pdf
-	latexmk -c $^
 
 .PHONY: requirements
 requirements:


### PR DESCRIPTION
This PR should create a new `gh-pages` branch with the latest cheatsheets. The `gh-pages` branch will not keep track of changes, rather, the cheatsheets will be replaced with each new commit to `master`. With GitHub Pages working properly, the PDFs and PNGs will be available at https://matplotlib.org/cheatsheets/cheatsheets.pdf, and so on.