### PR TITLE
fix matplotlib logo

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,6 +5,14 @@ current_version = 3.4.2
 search = Matplotlib {current_version}
 replace = Matplotlib {new_version}
 
+[bumpversion:file:./Makefile]
+search = v{current_version}
+replace = v{new_version}
+
+[bumpversion:file:./cheatsheets.tex]
+search = Version {current_version}
+replace = Version {new_version}
+
 [bumpversion:file:./requirements/requirements.in]
 search = matplotlib=={current_version}
 replace = matplotlib=={new_version}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: logos figures cheatsheets handouts
 
 .PHONY: logos
 logos:
-	cd logos && python mpl-logos2.py && pdfcrop mpl-logo2.pdf mpl-logo2.pdf
+	wget https://github.com/matplotlib/matplotlib/raw/v3.4.2/doc/_static/logo2.png -O ./logos/logo2.png
 
 .PHONY: figures
 figures:

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -16,6 +16,7 @@
 % --- Graphics ----------------------------------------------------------------
 \usepackage{tikz}
 \usepackage{graphicx}
+\usepackage[percent]{overpic}
 \graphicspath{{./figures/}{./icons/}{./logos/}}
 \usepackage[export]{adjustbox}
 
@@ -260,8 +261,10 @@
 \scriptsize
 
 \begin{multicols*}{5}
-
-  \includegraphics[width=\columnwidth]{mpl-logo2.pdf}
+  \begin{overpic}[width=\columnwidth,tics=6,trim=12 6 18 6, clip]{logo2.png}
+    \put (16.5,1.5) {\scriptsize\RobotoCon \textcolor[HTML]{11557c}{Cheat sheet}}
+    \put (80,1.5) {\tiny\Roboto \textcolor[HTML]{11557c}{Version 3.4.2}}
+   \end{overpic}
   %\textbf{\Large \RobotoCon Matplotlib 3.2 cheat sheet}\\
   %{\ttfamily https://matplotlib.org} \hfill CC-BY 4.0
   % \bigskip


### PR DESCRIPTION
Fix the matplotlib logo in the cheatsheets according to the suggestion https://github.com/matplotlib/cheatsheets/pull/61#issuecomment-907870441 from @timhoffm.

If it is straightforward to make the Calibri font available on the GHA machine, then the script method for generating the logo could continue. 