### PR TITLE
update selection of interpolation methods

### DIFF
--- a/scripts/interpolations.py
+++ b/scripts/interpolations.py
@@ -13,7 +13,7 @@ fig, axs = plt.subplots(nrows=6, ncols=3, figsize=(4.5,9),
                         subplot_kw={'xticks': [], 'yticks': []})
 for ax, interp_method in zip(axs.flat, methods):
     ax.imshow(Z, interpolation=interp_method, cmap='viridis',
-              extent=[0,9,0,9])
+              extent=[0,9,0,9], rasterized=True)
     ax.text(4.5, 1, str(interp_method), weight="bold", color="white", size=12,
             transform=ax.transData, ha="center", va="center")
 


### PR DESCRIPTION
Attempts to address #28.

- replace `'none'` with `blackman`

Something else to consider would be making the image data the same as what is used in the current matplotlib [gallery example](https://matplotlib.org/stable/gallery/images_contours_and_fields/interpolation_methods.html) for the interpolation methods. To that effect, I could add a commit to this PR.