### PR TITLE
DOC: add link to github to page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,3 +62,9 @@ Handouts
          :alt: image of tips handout
 
       `Tips [pdf] <./handout-tips.pdf>`_
+
+Contribute
+**********
+
+Issues, suggestions, or pull-requests gratefully accepted at
+`matplotlib/cheatsheets <https://github.com/matplotlib/cheatsheets>`_


### PR DESCRIPTION
Note that the "social" link at the top links to matplotlib's repo, not the cheatsheets.  Not sure if that should be fixed somehow - its kind of nice for this to look like it is part of Matplotlib and keep the top nav consistent. However, this seems good as a stopgap...