### PR TITLE
Fix various typos and inconsistencies

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -968,12 +968,12 @@
     \hspace*{2.5mm}~$\rightarrow$ fig.savefig("figure.pdf")\\
     \textbf{… save a transparent figure?}\\
     \hspace*{2.5mm}~$\rightarrow$ fig.savefig("figure.pdf", transparent=True)\\
-    \textbf{… clear a figure?}\\
-    \hspace*{2.5mm}~$\rightarrow$ ax.clear()\\
+    \textbf{… clear a figure/an axes?}\\
+    \hspace*{2.5mm}~$\rightarrow$ fig.clear() $\rightarrow$ ax.clear()\\
     \textbf{… close all figures?}\\
     \hspace*{2.5mm}~$\rightarrow$ plt.close("all")\\
     \textbf{… remove ticks?}\\
-    \hspace*{2.5mm}~$\rightarrow$ ax.set\_xticks([])\\
+    \hspace*{2.5mm}~$\rightarrow$ ax.set\_[xy]ticks([])\\
     \textbf{… remove tick labels ?}\\
     \hspace*{2.5mm}~$\rightarrow$ ax.set\_[xy]ticklabels([])\\
     \textbf{… rotate tick labels ?}\\

--- a/scripts/anatomy.py
+++ b/scripts/anatomy.py
@@ -49,7 +49,7 @@ ax.set_title("Anatomy of a figure", fontsize=20, verticalalignment='bottom')
 ax.set_xlabel("X axis label")
 ax.set_ylabel("Y axis label")
 
-ax.legend()
+ax.legend(loc="upper right")
 
 
 def circle(x, y, radius=0.15):

--- a/scripts/annotate.py
+++ b/scripts/annotate.py
@@ -17,10 +17,10 @@ plt.scatter([5.5], [0.75], s=100, c="k")
 plt.xlim(0, 6), plt.ylim(0, 1)
 plt.xticks([]), plt.yticks([])
 
-plt.annotate("Annotation", (5.5, .75), (0.1, .75), size=16, va="center",
+plt.annotate("text", (5.5, .75), (0.75, .75), size=16, va="center", ha="center",
              arrowprops=dict(facecolor='black', shrink=0.05))
 
-plt.text( 5.5, 0.6, "xy\nycoords", size=10, va="top", ha="center", color=".5")
+plt.text( 5.5, 0.6, "xy\nxycoords", size=10, va="top", ha="center", color=".5")
 plt.text( .75, 0.6, "xytext\ntextcoords", size=10, va="top", ha="center", color=".5")
 
 plt.savefig("../figures/annotate.pdf")


### PR DESCRIPTION
- annotation: missing x in xycoords and "text" instead of "Annotation"
  to correspond to function call signature above
- clear a figure how-to: make code correspond to heading
- remove ticks how-to: same for yaxis as is the other how-to's
- explicitly set legend location in anatomy.py as mpl 3.5.0 "best"
  default location results in lower right corner