### PR TITLE
Update Color Names plot

### DIFF
--- a/scripts/colornames.py
+++ b/scripts/colornames.py
@@ -2,25 +2,42 @@
 ========================
 Visualizing named colors
 ========================
-
 Simple plot example with the named colors and its visual representation.
 """
 from __future__ import division
+from itertools import groupby
 
 import matplotlib.pyplot as plt
 from matplotlib import colors as mcolors
-
+from matplotlib import rcParams
 
 colors = dict(mcolors.BASE_COLORS, **mcolors.CSS4_COLORS)
+colors.update(mcolors.TABLEAU_COLORS)
 
-# Sort colors by hue, saturation, value and name.
-by_hsv = sorted((tuple(mcolors.rgb_to_hsv(mcolors.to_rgba(color)[:3])), name)
-                for name, color in colors.items())
-sorted_names = [name for hsv, name in by_hsv]
+# Add default color cycler colors C0 ... C9
+std_cycle = {f'(C{i}⁺)': c for i, c in
+             enumerate(rcParams['axes.prop_cycle'].by_key()['color'])}
 
-n = len(sorted_names)
+colors.update(std_cycle)
+
+# Sort colors by hue, saturation, value
+by_hsv = sorted(((tuple(mcolors.rgb_to_hsv(mcolors.to_rgba(color)[:3])), name)
+                 for name, color in colors.items()), key=lambda x: x[0])
+
+
+# Group color synonyms
+def joiner(colornames):
+    """Join colornames by comma and replace gray/grey duplicates by gr[ae]y."""
+    return ', '.join([cn.replace('gray', 'gr[ae]y') for cn in colornames
+                      if 'grey' not in cn]).replace(', (', ' (')
+
+
+by_hsv = [(k, joiner([item[1] for item in g])) for k, g in
+          groupby(by_hsv, key=lambda x: x[0])]
+
+n = len(by_hsv)
 ncols = 3
-nrows = n // ncols +1
+nrows = n // ncols + 1
 
 fig, ax = plt.subplots(figsize=(4.5, 6))
 
@@ -29,9 +46,9 @@ X, Y = fig.get_dpi() * fig.get_size_inches()
 h = Y / (nrows + 1)
 w = X / ncols
 
-for i, name in enumerate(sorted_names):
-    col = i // (nrows-1)
-    row = i % (nrows-1)
+for i, (hsv, name) in enumerate(by_hsv):
+    col = i // (nrows - 1)
+    row = i % (nrows - 1)
     y = Y - (row * h) - h
 
     xi_line = w * (col + 0.05)
@@ -43,15 +60,17 @@ for i, name in enumerate(sorted_names):
             verticalalignment='center')
 
     ax.hlines(y + h * 0.1, xi_line, xf_line,
-              color=colors[name], linewidth=(h * 0.6))
+              color=mcolors.hsv_to_rgb(hsv), linewidth=(h * 0.6))
 
 ax.set_xlim(0, X)
 ax.set_ylim(0, Y)
 ax.set_axis_off()
 
 fig.subplots_adjust(left=0, right=1,
-                    top=1, bottom=0,
+                    top=1, bottom=0.01,
                     hspace=0, wspace=0)
+fig.text(0.5, 0.02, '⁺) C… represent the default color cycler values that can\
+         be re-assigned', fontsize=7, ha='center', va='bottom')
 
 plt.savefig("../figures/colornames.pdf")
 # plt.show()


### PR DESCRIPTION
- add default color cycler colors (`C0` ... `C9`)
- group synomys (e.g. `black, k` or `aqua, cyan`), combining gray and grey into gr[ae]y to save space
- some minor flake8 fixes

I think it's essential to show the default color cycler colors in this plot too. In order to not reduce the size of the color patches I've put color name synonyms together and combined the various ...gray/...grey names to ...gr[ae]y much in the same way as used elsewhere in this cheatsheet.  

![colornames_01](https://user-images.githubusercontent.com/19879328/145014479-25146931-54ec-4b25-9031-516aa614cc6c.png)

