### PR TITLE
bump matplotlib version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,10 @@
 [bumpversion]
 current_version = 3.4.2
 
+[bumpversion:file:./check-matplotlib-version.py]
+search = __version__ == '{current_version}'
+replace = __version__ == '{new_version}'
+
 [bumpversion:glob:./handout-*.tex]
 search = Matplotlib {current_version}
 replace = Matplotlib {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.2
+current_version = 3.5.0
 
 [bumpversion:file:./check-matplotlib-version.py]
 search = __version__ == '{current_version}'

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ handouts:
 
 .PHONY: check
 check:
+	./check-matplotlib-version.py
 	./check-num-pages.sh cheatsheets.pdf 2
 	./check-num-pages.sh handout-tips.pdf 1
 	./check-num-pages.sh handout-beginner.pdf 1

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: logos figures cheatsheets handouts docs
 
 .PHONY: logos
 logos:
-	wget https://github.com/matplotlib/matplotlib/raw/v3.4.2/doc/_static/logo2.png -O ./logos/logo2.png
+	wget https://github.com/matplotlib/matplotlib/raw/v3.5.0/doc/_static/logo2.png -O ./logos/logo2.png
 
 .PHONY: figures
 figures:

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -264,7 +264,7 @@
 \begin{multicols*}{5}
   \begin{overpic}[width=\columnwidth,tics=6,trim=12 6 18 6, clip]{logo2.png}
     \put (16.5,1.5) {\scriptsize\RobotoCon \textcolor[HTML]{11557c}{Cheat sheet}}
-    \put (80,1.5) {\tiny\Roboto \textcolor[HTML]{11557c}{Version 3.4.2}}
+    \put (80,1.5) {\tiny\Roboto \textcolor[HTML]{11557c}{Version 3.5.0}}
    \end{overpic}
   %\textbf{\Large \RobotoCon Matplotlib 3.2 cheat sheet}\\
   %{\ttfamily https://matplotlib.org} \hfill CC-BY 4.0

--- a/check-matplotlib-version.py
+++ b/check-matplotlib-version.py
@@ -2,4 +2,4 @@
 import matplotlib as mpl
 
 
-assert mpl.__version__ == '3.4.2'
+assert mpl.__version__ == '3.5.0'

--- a/check-matplotlib-version.py
+++ b/check-matplotlib-version.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+import matplotlib as mpl
+
+
+assert mpl.__version__ == '3.4.2'

--- a/handout-beginner.tex
+++ b/handout-beginner.tex
@@ -297,7 +297,7 @@ show the value under the mouse.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.4.2 handout for beginners.
+  Matplotlib 3.5.0 handout for beginners.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/handout-intermediate.tex
+++ b/handout-intermediate.tex
@@ -198,7 +198,7 @@ should be 3.15$\times$3.15 in.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.4.2 handout for intermediate users.
+  Matplotlib 3.5.0 handout for intermediate users.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/handout-tips.tex
+++ b/handout-tips.tex
@@ -243,7 +243,7 @@ gold-mine.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.4.2 handout for tips \& tricks.
+  Matplotlib 3.5.0 handout for tips \& tricks.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@ autopep8
 bump2version
 cartopy==0.19.0.post1
 flake8
-matplotlib==3.4.2
+matplotlib==3.5.0
 mpl-sphinx-theme
 pdfx
 pip-tools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -48,6 +48,8 @@ filelock==3.0.12
     # via virtualenv
 flake8==4.0.1
     # via -r requirements.in
+fonttools==4.28.3
+    # via matplotlib
 identify==2.2.2
     # via pre-commit
 idna==3.3
@@ -66,7 +68,7 @@ kiwisolver==1.3.1
     # via matplotlib
 markupsafe==2.0.1
     # via jinja2
-matplotlib==3.4.2
+matplotlib==3.5.0
     # via -r requirements.in
 mccabe==0.6.1
     # via flake8
@@ -80,7 +82,10 @@ numpy==1.19.5
     #   matplotlib
     #   scipy
 packaging==21.2
-    # via sphinx
+    # via
+    #   matplotlib
+    #   setuptools-scm
+    #   sphinx
 pdfminer.six==20201018
     # via pdfx
 pdfx==1.4.1
@@ -121,6 +126,8 @@ requests==2.26.0
     # via sphinx
 scipy==1.5.4
     # via -r requirements.in
+setuptools-scm==6.3.2
+    # via matplotlib
 shapely==1.7.1
     # via cartopy
 six==1.15.0
@@ -155,6 +162,8 @@ toml==0.10.2
     #   autopep8
     #   pep517
     #   pre-commit
+tomli==1.2.2
+    # via setuptools-scm
 typing-extensions==4.0.0
     # via importlib-metadata
 urllib3==1.26.7


### PR DESCRIPTION
Bump the version of matplotlib being used to generate the cheatsheets and handouts.

This is done with:
```shell
bumpversion minor && make requirements
```