### PR TITLE
Update for version 3.5.0

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -710,8 +710,8 @@
     ax.\textbf{grid}()\\
     ax.\textbf{set\_[xy]lim}(vmin, vmax)\\
     ax.\textbf{set\_[xy]label}(label)\\
-    ax.\textbf{set\_[xy]ticks}(list)\\
-    ax.\textbf{set\_[xy]ticklabels}(list)\\
+    ax.\textbf{set\_[xy]ticks}(ticks, [labels])\\
+    ax.\textbf{set\_[xy]ticklabels}(labels)\\
     ax.\textbf{set\_title}(title)\\
     ax.\textbf{tick\_params}(width=10, …)\\
     ax.\textbf{set\_axis\_[on|off]}()\\

--- a/scripts/annotation-arrow-styles.py
+++ b/scripts/annotation-arrow-styles.py
@@ -10,7 +10,7 @@ def demo_con_style(ax, connectionstyle):
             transform=ax.transAxes, ha="left", va="top", size="x-small")
 
 
-(fig, axes) = plt.subplots(5, 3, figsize=(4, 2.5), frameon=False)
+(fig, axes) = plt.subplots(4, 4, figsize=(4, 2.5), frameon=False)
 for ax in axes.flatten():
     ax.axis("off")
 for i, (ax, style) in enumerate(zip(axes.flatten(), mpatches.ArrowStyle.get_styles())):


### PR DESCRIPTION
- make room for two additional annotation arrow styles (so that `'wedge'` is show again)
- add possibility to set tick labels together with tick positions