### PR TITLE
Fix suptitle setting

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -708,19 +708,19 @@
   \begin{myboxed}{Quick reminder}
   {\ttfamily
     ax.\textbf{grid}()\\
-    ax.patch.\textbf{set\_alpha}(0)\\
     ax.\textbf{set\_[xy]lim}(vmin, vmax)\\
     ax.\textbf{set\_[xy]label}(label)\\
     ax.\textbf{set\_[xy]ticks}(list)\\
     ax.\textbf{set\_[xy]ticklabels}(list)\\
-    ax.\textbf{set\_[sup]title}(title)\\
+    ax.\textbf{set\_title}(title)\\
     ax.\textbf{tick\_params}(width=10, …)\\
     ax.\textbf{set\_axis\_[on|off]}()\\
     \\
+    fig.\textbf{suptitle}(title)\\
     fig.\textbf{tight\_layout}()\\
     plt.\textbf{gcf}(), plt.\textbf{gca}()\\
     mpl.\textbf{rc}('axes', linewidth=1, …)\\
-    fig.patch.\textbf{set\_alpha}(0)\\
+    {[fig|ax]}.patch.\textbf{set\_alpha}(0)\\
     \verb|text=r'$\frac{-e^{i\pi}}{2^n}$'|}
   \end{myboxed}
   %

--- a/handout-tips.tex
+++ b/handout-tips.tex
@@ -114,7 +114,7 @@ Use the Agg backend to render a figure directly in an array.
 \begin{lstlisting}
  from matplotlib.backends.backend_agg import FigureCanvas
  canvas = FigureCanvas(Figure()))
- ... # draw som stuff
+ ... # draw some stuff
  canvas.draw()
  Z = np.array(canvas.renderer.buffer_rgba())
 \end{lstlisting}


### PR DESCRIPTION
- change non-existing method `ax.set_suptitle` to `fig.suptitle` and
  combine `patch.set_alpha(0)` for `fig` and `ax` into one line to make
  room for new line `fig.suptitle()`
- fix typo