### PR TITLE
Simple fix

### DIFF
--- a/handout-intermediate.tex
+++ b/handout-intermediate.tex
@@ -83,7 +83,7 @@ the actual figure. Each element can be modified. \medskip
 % -----------------------------------------------------------------------------
 \begin{tabular}{@{}m{.821\linewidth}m{.169\linewidth}}
 \begin{lstlisting}[belowskip=-\baselineskip]
- fig, axs = plt.subplots((3,3))
+ fig, axs = plt.subplots(3,3)
  axs[0,0].set_facecolor("#ddddff")
  axs[2,2].set_facecolor("#ffffdd")
 \end{lstlisting}


### PR DESCRIPTION
Simple fix
Proof
```
[weissmann@larissa ~]$ ipython
Python 3.9.9 (main, Nov 20 2021, 21:30:06) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import matplotlib.pyplot as plt

In [2]: Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
In [2]: plt.subplots((3,3))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-93a8c9ce4987> in <module>
----> 1 plt.subplots((3,3))

/usr/lib/python3.9/site-packages/matplotlib/pyplot.py in subplots(nrows, ncols, sharex, sharey, squeeze, subplot_kw, gridspec_kw, **fig_kw)
   1433     """
   1434     fig = figure(**fig_kw)
-> 1435     axs = fig.subplots(nrows=nrows, ncols=ncols, sharex=sharex, sharey=sharey,
   1436                        squeeze=squeeze, subplot_kw=subplot_kw,
   1437                        gridspec_kw=gridspec_kw)

/usr/lib/python3.9/site-packages/matplotlib/figure.py in subplots(self, nrows, ncols, sharex, sharey, squeeze, subplot_kw, gridspec_kw)
    894         if gridspec_kw is None:
    895             gridspec_kw = {}
--> 896         gs = self.add_gridspec(nrows, ncols, figure=self, **gridspec_kw)
    897         axs = gs.subplots(sharex=sharex, sharey=sharey, squeeze=squeeze,
    898                           subplot_kw=subplot_kw)

/usr/lib/python3.9/site-packages/matplotlib/figure.py in add_gridspec(self, nrows, ncols, **kwargs)
   1389 
   1390         _ = kwargs.pop('figure', None)  # pop in case user has added this...
-> 1391         gs = GridSpec(nrows=nrows, ncols=ncols, figure=self, **kwargs)
   1392         self._gridspecs.append(gs)
   1393         return gs

/usr/lib/python3.9/site-packages/matplotlib/gridspec.py in __init__(self, nrows, ncols, figure, left, bottom, right, top, wspace, hspace, width_ratios, height_ratios)
    381         self.figure = figure
    382 
--> 383         super().__init__(nrows, ncols,
    384                          width_ratios=width_ratios,
    385                          height_ratios=height_ratios)

/usr/lib/python3.9/site-packages/matplotlib/gridspec.py in __init__(self, nrows, ncols, height_ratios, width_ratios)
     45         """
     46         if not isinstance(nrows, Integral) or nrows <= 0:
---> 47             raise ValueError(
     48                 f"Number of rows must be a positive integer, not {nrows!r}")
     49         if not isinstance(ncols, Integral) or ncols <= 0:

ValueError: Number of rows must be a positive integer, not (3, 3)

In [3]: 
```