### PR TITLE
Replace step with stairs and correct subplot_adjusts

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -432,14 +432,13 @@
   \vspace{\fill}
   % --- Advanced plots --------------------------------------------------------
   \begin{myboxed}{Advanced plots}
-  \plot{advanced-step.pdf}{\textbf{step}(X,Y,[fmt],…)}
-     {https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.step.html}
-     {\mandatory{X},
-      \mandatory{Y},
-      \optional{fmt},
-      \optional{color},
-      \optional{marker},
-      \optional{where} }
+  \plot{advanced-stairs.pdf}{\textbf{stairs}(Y,[edges],…)}
+     {https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.stairs.html}
+     {\mandatory{Y},
+      \optional{edges},
+      \optional{orientation},
+      \optional{baseline},
+      \optional{fill} }
      {}
   \plot{advanced-boxplot.pdf}{\textbf{boxplot}(X,…)}
      {https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.boxplot.html}

--- a/scripts/adjustements.py
+++ b/scripts/adjustements.py
@@ -48,16 +48,16 @@ plt.scatter(X, Y, s=75, zorder=10,
 
 # Window size extension
 X, Y = [0, 0], [0, -8]
-plt.plot(X, Y, color="black", linestyle=":", linewidth=1, clip_on=False)
+plt.plot(X, Y, color="gray", zorder=0, linewidth=1, clip_on=False)
 
 X, Y = [100, 100], [0, -8]
-plt.plot(X, Y, color="black", linestyle=":", linewidth=1, clip_on=False)
+plt.plot(X, Y, color="gray", zorder=0, linewidth=1, clip_on=False)
 
 X, Y = [100, 108], [0, 0]
-plt.plot(X, Y, color="black", linestyle=":", linewidth=1, clip_on=False)
+plt.plot(X, Y, color="gray", zorder=0, linewidth=1, clip_on=False)
 
 X, Y = [100, 108], [75, 75]
-plt.plot(X, Y, color="black", linestyle=":", linewidth=1, clip_on=False)
+plt.plot(X, Y, color="gray", zorder=0, linewidth=1, clip_on=False)
 
 
 def ext_arrow(p0, p1, p2, p3):
@@ -65,21 +65,21 @@ def ext_arrow(p0, p1, p2, p3):
     p2, p3 = np.asarray(p2), np.asarray(p3)
     ax.arrow(*p0, *(p1-p0), zorder=20, linewidth=0,
              length_includes_head=True, width=.4,
-             head_width=2, head_length=2, color="black")
+             head_width=2, head_length=2, color="gray")
     ax.arrow(*p3, *(p2-p3), zorder=20, linewidth=0,
              length_includes_head=True, width=.4,
-             head_width=2, head_length=2, color="black")
-    plt.plot([p1[0], p2[0]], [p1[1], p2[1]], linewidth=.9, color="black")
+             head_width=2, head_length=2, color="gray")
+    plt.plot([p1[0], p2[0]], [p1[1], p2[1]], zorder=20, linewidth=.9, color="gray")
 
 
 def int_arrow(p0, p1):
     p0, p1 = np.asarray(p0), np.asarray(p1)
     ax.arrow(*((p0+p1)/2), *((p1-p0)/2), zorder=20, linewidth=0,
              length_includes_head=True, width=.4,
-             head_width=2, head_length=2, color="black")
+             head_width=2, head_length=2, color="gray")
     ax.arrow(*((p0+p1)/2), *(-(p1-p0)/2), zorder=20, linewidth=0,
              length_includes_head=True, width=.4,
-             head_width=2, head_length=2, color="black")
+             head_width=2, head_length=2, color="gray")
 
 
 x = 0
@@ -91,12 +91,13 @@ x += 50
 ext_arrow( (x-4, y), (x, y), (x+5, y), (x+9, y) )
 ax.text(x-4.5, y, "wspace", ha="right", va="center", size="x-small", zorder=20)
 
-x += 45
-ext_arrow( (x-4, y), (x, y), (x+5, y), (x+9, y) )
-ax.text(x-4.5, y, "right", ha="right", va="center", size="x-small", zorder=20)
+y=20
+int_arrow( (0, y), (95, y))
+ax.text(80, y, "right", backgroundcolor="white", ha="right", va="center",
+        size="x-small", zorder=30)
 
 y = 0
-x = 25
+x = 22.5
 ext_arrow( (x, y-4), (x, y), (x, y+5), (x, y+9) )
 ax.text(x, y+9.5, "bottom", ha="center", va="bottom", size="x-small", zorder=20)
 
@@ -104,9 +105,10 @@ y += 35
 ext_arrow( (x, y-4), (x, y), (x, y+5), (x, y+9) )
 ax.text(x, y-4.5, "hspace", ha="center", va="top", size="x-small", zorder=20)
 
-y += 35
-ext_arrow( (x, y-4), (x, y), (x, y+5), (x, y+9) )
-ax.text(x, y-4.5, "top", ha="center", va="top", size="x-small", zorder=20)
+x = 31
+int_arrow( (x, 0), (x, 70))
+ax.text(x, 55, "top", backgroundcolor="white", rotation="vertical",
+        ha="center", va="center", size="x-small", zorder=30)
 
 int_arrow((0, -5), (100, -5))
 ax.text(50, -5, "figure width", backgroundcolor="white", zorder=30,

--- a/scripts/advanced-plots.py
+++ b/scripts/advanced-plots.py
@@ -3,7 +3,7 @@
 # Released under the BSD License
 # -----------------------------------------------------------------------------
 
-# Scripts to generate all the basic plots
+# Scripts to generate all the advanced plots
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -15,15 +15,17 @@ mpl.rcParams['ytick.major.size'] = 0.0
 d = 0.01
 ax = fig.add_axes([d, d, 1-2*d, 1-2*d])
 
-# Step plot
+# Stairs plot
 # -----------------------------------------------------------------------------
-X = np.linspace(0, 10, 16)
-Y = 4 + 2*np.sin(2*X)
-ax.step(X, Y, color="C1", linewidth=0.75)
+X = np.linspace(0, 2*np.pi, 9)
+Y = 2*np.sin(3*X)
+Y[7:] = 0
+ax.stairs(Y, color="C1", linewidth=0.75)
 ax.set_xlim(0, 8), ax.set_xticks(np.arange(1, 8))
-ax.set_ylim(0, 8), ax.set_yticks(np.arange(1, 8))
+ax.set_ylim(-4, 4), ax.set_yticks(np.arange(-4, 4))
+ax.set_axisbelow(True)
 ax.grid(linewidth=0.125)
-plt.savefig("../figures/advanced-step.pdf")
+plt.savefig("../figures/advanced-stairs.pdf")
 ax.clear()
 
 # Violin plot


### PR DESCRIPTION
Closes #109 
Closes #111 

Hard to make the `subplot_adjusts` figure look really good, but here is the update one:
![image](https://user-images.githubusercontent.com/8114497/169652955-90e4fc0e-19b5-4447-8182-2b51cd81bb48.png)

Stairs illustration:
![image](https://user-images.githubusercontent.com/8114497/169652989-469230df-2b56-4704-a139-41fb551b6c82.png)

(Both are screen shots of the PDF.)

Not obvious which arguments should be used. I went with those that are (a bit) "special" for `stairs`.