### PR TITLE
Improve tick label rotation method

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -977,7 +977,7 @@
     \textbf{… remove tick labels ?}\\
     \hspace*{2.5mm}~$\rightarrow$ ax.set\_[xy]ticklabels([])\\
     \textbf{… rotate tick labels ?}\\
-    \hspace*{2.5mm}~$\rightarrow$ ax.set\_[xy]ticks(rotation=90)\\
+    \hspace*{2.5mm}~$\rightarrow$ ax.tick\_params(axis="x", rotation=90)\\
     \textbf{… hide top spine?}\\
     \hspace*{2.5mm}~$\rightarrow$ ax.spines['top'].set\_visible(False)\\
     \textbf{… hide legend border?}\\


### PR DESCRIPTION
Using `ax.set_xticks(rotation=90)` without passing labels is discouraged by the documentation. It recommends `ax.tick_params(axis='x', rotation=90)` instead.

Closes #108.