### PR TITLE
Change casing of sentences

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -760,16 +760,16 @@
   %
   \begin{myboxed}{Ten simple rules \hfill
       \READ{https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003833}}
-    1. Know Your Audience\\
-    2. Identify Your Message\\
-    3. Adapt the Figure\\
-    4. Captions Are Not Optional\\
-    5. Do Not Trust the Defaults\\
-    6. Use Color Effectively\\
-    7. Do Not Mislead the Reader\\
-    8. Avoid “Chartjunk”\\
-    9. Message Trumps Beauty\\
-    10. Get the Right Tool
+    1. Know your audience\\
+    2. Identify your message\\
+    3. Adapt the figure\\
+    4. Captions are not optional\\
+    5. Do not trust the defaults\\
+    6. Use color effectively\\
+    7. Do not mislead the reader\\
+    8. Avoid “chartjunk”\\
+    9. Message trumps beauty\\
+    10. Get the right tool
   \end{myboxed}
 \end{multicols*}
 
@@ -1028,12 +1028,12 @@
   %
   \begin{myboxed}{Beyond Matplotlib}
         \smallskip
-    \href{https://seaborn.pydata.org/}{\textbf{Seaborn}}: Statistical Data Visualization\\
-    \href{https://scitools.org.uk/cartopy/docs/latest/}{\textbf{Cartopy}}: Geospatial Data Processing\\
-    \href{https://yt-project.org/doc/index.html}{\textbf{yt}}: Volumetric data Visualization\\
+    \href{https://seaborn.pydata.org/}{\textbf{Seaborn}}: Statistical data visualization\\
+    \href{https://scitools.org.uk/cartopy/docs/latest/}{\textbf{Cartopy}}: Geospatial data processing\\
+    \href{https://yt-project.org/doc/index.html}{\textbf{yt}}: Volumetric data visualization\\
     \href{https://mpld3.github.io}{\textbf{mpld3}}: Bringing Matplotlib to the browser\\
     \href{https://datashader.org/}{\textbf{Datashader}}: Large data processing pipeline\\
-    \href{https://plotnine.readthedocs.io/en/latest/}{\textbf{plotnine}}: A Grammar of Graphics for Python
+    \href{https://plotnine.readthedocs.io/en/latest/}{\textbf{plotnine}}: A grammar of graphics for Python
   \end{myboxed}
   %
   \begin{center}


### PR DESCRIPTION
Change the casing in two locations.

### Ten simple rules

Although the casing corresponds to the section titles of the original paper, the cheat sheet does not even use title casing for its titles.

### Beyond Matplotlib

Inconsistent within the list, and with the argument of title case not even being used for titles, sentence case seems better.