### PR TITLE
Fix non-existent cartopy projection

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -519,17 +519,11 @@
   {\ttfamily \textbf{subplot}(…,projection=p)}
   \smallskip
   \scale{projection-polar.pdf}{p='polar'}{}
-  \scale{projection-3d.pdf}{p='3d'}{}
-%       {https://matplotlib.org/stable/api/projections_api.html}
-%       {}
-%       {}
-  %% \plot{projection-3d.pdf}{p='3d'}
-  %%      {https://matplotlib.org/stable/api/toolkits/mplot3d.html}
-  %%      {}
-  %%      {}
-  \plot{projection-cartopy.pdf}{p=Orthographic()}
-       {https://matplotlib.org/stable/api/toolkits/mplot3d.html}
-       {from cartopy.crs import Cartographic}
+  \scale{projection-3d.pdf}
+      {p='3d'\hfill\api{https://matplotlib.org/stable/api/toolkits/mplot3d.html}}{}
+  \plot{projection-cartopy.pdf}{p=ccrs.Orthographic()}
+       {https://scitools.org.uk/cartopy/docs/latest/reference/projections.html}
+       {import cartopy.crs as ccrs}
        {}
   \end{myboxed}
   %

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -328,7 +328,7 @@
     \href{https://stackoverflow.com/questions/tagged/matplotlib}
          {\faIcon{stack-overflow}\,stackoverflow.com/questions/tagged/matplotlib}\\
     \href{https://gitter.im/matplotlib/matplotlib}
-         {\faIcon{gitter}\,gitter.im/matplotlib}\\
+         {\faIcon{gitter}\,{https://gitter.im/matplotlib/matplotlib}}\\
     \href{https://twitter.com/matplotlib}
          {\faIcon{twitter}\,twitter.com/matplotlib}\\
     \href{https://mail.python.org/mailman/listinfo/matplotlib-users}


### PR DESCRIPTION
- the correct name of the projection is Orthographic instead of Cartographic.
- use standard import convention to make the line a bit shorter,
  see https://scitools.org.uk/cartopy/docs/latest/matplotlib/intro.html.
- fix wrong API link for cartopy
- add missing (lost) API link for 3d

![grafik](https://user-images.githubusercontent.com/19879328/223661526-9ea0b87d-5785-4774-9f99-1040bd2cc1d5.png)

Also removed some commented lines from previous changes, as I think the history should be better looked up in version control than in the code itself.