### PR TITLE
Replace calls to fig.show() with plt.show()

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -289,7 +289,7 @@
   ax.plot(X, Y, color='green')\\
   \\
   fig.savefig(``figure.pdf'')\\
-  fig.show() }
+  plt.show() }
   \end{myboxed}
   \vspace{\fill}
 

--- a/handout-beginner.tex
+++ b/handout-beginner.tex
@@ -91,7 +91,7 @@ with just a few commands:\\
 \begin{lstlisting}
  fig, ax = plt.subplots()
  ax.plot(X, Y)
- fig.show()
+ plt.show()
 \end{lstlisting}
 %
 \fbox{4} \textbf{Observe} \medskip\\


### PR DESCRIPTION
Some examples call `fig.show()` with the expectation that a matpltolib figure will be displayed on-screen. However, since `fig.show` does not manage the backed GUI mainloop this will seemingly fail. In most cases, it will be more convenient for end-users to rely on `plt.show` to display figures.

Resolves #134 