### PR TITLE
fix(sec): upgrade wheel to 0.38.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -164,7 +164,7 @@ urllib3==1.26.8
     # via requests
 virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.1
+wheel==0.38.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in wheel 0.37.1
- [CVE-2022-40898](https://www.oscs1024.com/hd/CVE-2022-40898)


### What did I do？
Upgrade wheel from 0.37.1 to 0.38.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS