### PR TITLE
Bump pre-commit action version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
   build:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
The older one was giving deprecation warnings at the end of a build.