### PR TITLE
Bump version of Matplotlib sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ author = "Matplotlib Developers"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["sphinx_design"]
 
 # Add any paths that contain templates here, relative to this directory.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Cheatsheets
 Handouts
 ********
 
-.. grid:: 3
+.. grid:: 1 2 3 3
 
     .. grid-item::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,23 +7,21 @@ Matplotlib cheatsheets and handouts
 Cheatsheets
 ***********
 
-.. container:: twocol
+.. grid:: 2
 
-    .. container::
+    .. grid-item::
 
-      .. image:: ../cheatsheets-1.png
-         :width: 270px
-         :align: center
-         :alt: image of first page of cheatsheets
+        .. image:: ../cheatsheets-1.png
+            :width: 270px
+            :align: center
+            :alt: image of first page of cheatsheets
 
+    .. grid-item::
 
-    .. container::
-
-      .. image:: ../cheatsheets-2.png
-         :width: 270px
-         :align: center
-         :alt: image of second page of cheatsheets
-
+        .. image:: ../cheatsheets-2.png
+            :width: 270px
+            :align: center
+            :alt: image of second page of cheatsheets
 
 `Cheatsheets [pdf] <./cheatsheets.pdf>`_
 
@@ -32,36 +30,34 @@ Cheatsheets
 Handouts
 ********
 
-.. container:: twocol
+.. grid:: 3
 
-   .. container::
+    .. grid-item::
 
-      .. image:: ../handout-beginner.png
-         :width: 270px
-         :align: center
-         :alt: image of beginner handout
+        .. image:: ../handout-beginner.png
+            :width: 270px
+            :align: center
+            :alt: image of beginner handout
 
-      `Beginner [pdf] <./handout-beginner.pdf>`_
+        `Beginner [pdf] <./handout-beginner.pdf>`_
 
+    .. grid-item::
 
-   .. container::
+        .. image:: ../handout-intermediate.png
+            :width: 270px
+            :align: center
+            :alt: image of intermediate handout
 
-      .. image:: ../handout-intermediate.png
-         :width: 270px
-         :align: center
-         :alt: image of intermediate handout
+        `Intermediate [pdf] <./handout-intermediate.pdf>`_
 
-      `Intermediate [pdf] <./handout-intermediate.pdf>`_
+    .. grid-item::
 
+        .. image:: ../handout-tips.png
+            :width: 270px
+            :align: center
+            :alt: image of tips handout
 
-   .. container::
-
-      .. image:: ../handout-tips.png
-         :width: 270px
-         :align: center
-         :alt: image of tips handout
-
-      `Tips [pdf] <./handout-tips.pdf>`_
+        `Tips [pdf] <./handout-tips.pdf>`_
 
 Contribute
 **********

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,6 +9,7 @@ pip-tools
 pre-commit
 scipy
 # Docs
-mpl-sphinx-theme==3.8.0
+mpl-sphinx-theme~=3.8
 pydata-sphinx-theme==0.13.3
 sphinx
+sphinx-design

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,7 +9,7 @@ pip-tools
 pre-commit
 scipy
 # Docs
-mpl-sphinx-theme~=3.8
+mpl-sphinx-theme~=3.8.0
 pydata-sphinx-theme==0.13.3
 sphinx
 sphinx-design

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,10 +3,12 @@ bump2version
 cartopy==0.22.0
 flake8
 matplotlib==3.7.4
-mpl-sphinx-theme~=3.7.1
 pillow>=9
 pdfx
 pip-tools
 pre-commit
 scipy
+# Docs
+mpl-sphinx-theme==3.8.0
+pydata-sphinx-theme==0.13.3
 sphinx

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -75,7 +75,7 @@ matplotlib==3.7.4
     #   mpl-sphinx-theme
 mccabe==0.7.0
     # via flake8
-mpl-sphinx-theme==3.7.1
+mpl-sphinx-theme==3.8.0
     # via -r requirements.in
 nodeenv==1.8.0
     # via pre-commit
@@ -113,8 +113,10 @@ pycodestyle==2.11.1
     #   flake8
 pycparser==2.21
     # via cffi
-pydata-sphinx-theme==0.15.2
-    # via mpl-sphinx-theme
+pydata-sphinx-theme==0.13.3
+    # via
+    #   -r requirements.in
+    #   mpl-sphinx-theme
 pyflakes==3.2.0
     # via flake8
 pygments==2.17.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -154,6 +154,9 @@ sphinx==7.2.6
     # via
     #   -r requirements.in
     #   pydata-sphinx-theme
+    #   sphinx-design
+sphinx-design==0.5.0
+    # via -r requirements.in
 sphinxcontrib-applehelp==1.0.8
     # via sphinx
 sphinxcontrib-devhelp==1.0.6


### PR DESCRIPTION
This updates the sphinx theme versions to match the ones currently used by `matplotlib`. This should bring the appearance of https://matplotlib.org/cheatsheets/ into line with https://matplotlib.org/ and the main docs site.

Note that this deliberately downgrades `pydata-sphinx-theme` because of https://github.com/matplotlib/mpl-sphinx-theme/issues/80. The new pin is `0.13.3`, which is what the main Matplotlib docs currently use.