### PR TITLE
Bump Matplotlib to 3.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.0
+current_version = 3.6.3
 
 [bumpversion:file:./check-matplotlib-version.py]
 search = __version__ == '{current_version}'

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: logos figures cheatsheets handouts docs
 
 .PHONY: logos
 logos:
-	wget https://github.com/matplotlib/matplotlib/raw/v3.5.0/doc/_static/logo2.png -O ./logos/logo2.png
+	wget https://github.com/matplotlib/matplotlib/raw/v3.6.3/doc/_static/logo2.png -O ./logos/logo2.png
 
 .PHONY: figures
 figures:

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -682,19 +682,11 @@
     \fbox{\includegraphics[width=.32\columnwidth]{style-classic.pdf}}
     \fbox{\includegraphics[width=.32\columnwidth]{style-grayscale.pdf}}
     \fbox{\includegraphics[width=.32\columnwidth]{style-ggplot.pdf}}
-    \fbox{\includegraphics[width=.32\columnwidth]{style-seaborn.pdf}}
+    \fbox{\includegraphics[width=.32\columnwidth]{style-seaborn-v0_8.pdf}}
     \fbox{\includegraphics[width=.32\columnwidth]{style-fast.pdf}}
     \fbox{\includegraphics[width=.32\columnwidth]{style-bmh.pdf}}
     \fbox{\includegraphics[width=.32\columnwidth]{style-Solarize_Light2.pdf}}
-    \fbox{\includegraphics[width=.32\columnwidth]{style-seaborn-notebook.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-default.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-classic.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-grayscale.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-ggplot.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-seaborn.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-fast.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-bmh.pdf}}
-    %% \fbox{\includegraphics[width=.24\columnwidth]{style-Solarize_Light2.pdf}}
+    \fbox{\includegraphics[width=.32\columnwidth]{style-seaborn-v0_8-notebook.pdf}}
   \end{myboxed}
   %
   \vspace{\fill}

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -264,7 +264,7 @@
 \begin{multicols*}{5}
   \begin{overpic}[width=\columnwidth,tics=6,trim=12 6 18 6, clip]{logo2.png}
     \put (16.5,1.5) {\scriptsize\RobotoCon \textcolor[HTML]{11557c}{Cheat sheet}}
-    \put (80,1.5) {\tiny\Roboto \textcolor[HTML]{11557c}{Version 3.5.0}}
+    \put (80,1.5) {\tiny\Roboto \textcolor[HTML]{11557c}{Version 3.6.3}}
    \end{overpic}
   %\textbf{\Large \RobotoCon Matplotlib 3.2 cheat sheet}\\
   %{\ttfamily https://matplotlib.org} \hfill CC-BY 4.0

--- a/check-matplotlib-version.py
+++ b/check-matplotlib-version.py
@@ -2,4 +2,4 @@
 import matplotlib as mpl
 
 
-assert mpl.__version__ == '3.5.0'
+assert mpl.__version__ == '3.6.3'

--- a/handout-beginner.tex
+++ b/handout-beginner.tex
@@ -297,7 +297,7 @@ show the value under the mouse.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.5.0 handout for beginners.
+  Matplotlib 3.6.3 handout for beginners.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/handout-intermediate.tex
+++ b/handout-intermediate.tex
@@ -198,7 +198,7 @@ should be 3.15$\times$3.15 in.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.5.0 handout for intermediate users.
+  Matplotlib 3.6.3 handout for intermediate users.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/handout-tips.tex
+++ b/handout-tips.tex
@@ -243,7 +243,7 @@ gold-mine.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.5.0 handout for tips \& tricks.
+  Matplotlib 3.6.3 handout for tips \& tricks.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@ autopep8
 bump2version
 cartopy==0.22.0
 flake8
-matplotlib==3.5.0
+matplotlib==3.6.3
 mpl-sphinx-theme
 pillow>=9
 pdfx

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -34,6 +34,8 @@ charset-normalizer==2.0.12
     # via requests
 click==8.0.4
     # via pip-tools
+contourpy==1.2.0
+    # via matplotlib
 cryptography==36.0.1
     # via pdfminer-six
 cycler==0.11.0
@@ -62,7 +64,7 @@ kiwisolver==1.3.2
     # via matplotlib
 markupsafe==2.1.0
     # via jinja2
-matplotlib==3.5.0
+matplotlib==3.6.3
     # via
     #   -r requirements.in
     #   cartopy
@@ -75,13 +77,13 @@ nodeenv==1.6.0
 numpy==1.22.2
     # via
     #   cartopy
+    #   contourpy
     #   matplotlib
     #   scipy
 packaging==21.3
     # via
     #   cartopy
     #   matplotlib
-    #   setuptools-scm
     #   sphinx
 pdfminer-six==20201018
     # via pdfx
@@ -129,8 +131,6 @@ requests==2.27.1
     # via sphinx
 scipy==1.8.0
     # via -r requirements.in
-setuptools-scm==6.4.2
-    # via matplotlib
 shapely==1.8.1.post1
     # via cartopy
 six==1.16.0
@@ -164,9 +164,7 @@ toml==0.10.2
     #   autopep8
     #   pre-commit
 tomli==2.0.1
-    # via
-    #   pep517
-    #   setuptools-scm
+    # via pep517
 urllib3==1.26.8
     # via requests
 virtualenv==20.13.1


### PR DESCRIPTION
I figure it might be easier doing the Matplotlib version bumps one meso version at a time, to make PRs easier to review, and to make any changes to the cheatsheets easier to understand/debug/fix.