### PR TITLE
Update Matplotlib version to 3.8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.7.4
+current_version = 3.8.2
 
 [bumpversion:file:./check-matplotlib-version.py]
 search = __version__ == '{current_version}'

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,7 @@ CONVERTFLAGS = -density 150 -alpha remove -depth 8
 default: all
 
 .PHONY: all
-all: logos figures cheatsheets handouts docs
-
-.PHONY: logos
-logos:
-	wget https://github.com/matplotlib/matplotlib/raw/v3.8.2/doc/_static/logo2.png -O ./logos/logo2.png
+all: figures cheatsheets handouts docs
 
 .PHONY: figures
 figures:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: logos figures cheatsheets handouts docs
 
 .PHONY: logos
 logos:
-	wget https://github.com/matplotlib/matplotlib/raw/v3.7.4/doc/_static/logo2.png -O ./logos/logo2.png
+	wget https://github.com/matplotlib/matplotlib/raw/v3.8.2/doc/_static/logo2.png -O ./logos/logo2.png
 
 .PHONY: figures
 figures:

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -264,7 +264,7 @@
 \begin{multicols*}{5}
   \begin{overpic}[width=\columnwidth,tics=6,trim=12 6 18 6, clip]{logo2.png}
     \put (16.5,1.5) {\scriptsize\RobotoCon \textcolor[HTML]{11557c}{Cheat sheet}}
-    \put (80,1.5) {\tiny\Roboto \textcolor[HTML]{11557c}{Version 3.7.4}}
+    \put (80,1.5) {\tiny\Roboto \textcolor[HTML]{11557c}{Version 3.8.2}}
    \end{overpic}
   %\textbf{\Large \RobotoCon Matplotlib 3.2 cheat sheet}\\
   %{\ttfamily https://matplotlib.org} \hfill CC-BY 4.0

--- a/check-matplotlib-version.py
+++ b/check-matplotlib-version.py
@@ -2,4 +2,4 @@
 import matplotlib as mpl
 
 
-assert mpl.__version__ == '3.7.4'
+assert mpl.__version__ == '3.8.2'

--- a/handout-beginner.tex
+++ b/handout-beginner.tex
@@ -297,7 +297,7 @@ show the value under the mouse.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.7.4 handout for beginners.
+  Matplotlib 3.8.2 handout for beginners.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/handout-intermediate.tex
+++ b/handout-intermediate.tex
@@ -198,7 +198,7 @@ should be 3.15$\times$3.15\,in.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.7.4 handout for intermediate users.
+  Matplotlib 3.8.2 handout for intermediate users.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/handout-tips.tex
+++ b/handout-tips.tex
@@ -243,7 +243,7 @@ gold-mine.
 \vfill
 %
 {\scriptsize
-  Matplotlib 3.7.4 handout for tips \& tricks.
+  Matplotlib 3.8.2 handout for tips \& tricks.
   Copyright (c) 2021 Matplotlib Development Team.
   Released under a CC-BY 4.0 International License.
   Supported by NumFOCUS.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,8 @@ autopep8
 bump2version
 cartopy==0.22.0
 flake8
-matplotlib==3.7.4
+matplotlib==3.8.2
+mpl-sphinx-theme~=3.7.1
 pillow>=9
 pdfx
 pip-tools

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,6 @@ bump2version
 cartopy==0.22.0
 flake8
 matplotlib==3.8.2
-mpl-sphinx-theme~=3.7.1
 pillow>=9
 pdfx
 pip-tools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -68,7 +68,7 @@ kiwisolver==1.4.5
     # via matplotlib
 markupsafe==2.1.4
     # via jinja2
-matplotlib==3.7.4
+matplotlib==3.8.2
     # via
     #   -r requirements.in
     #   cartopy

--- a/scripts/markers.py
+++ b/scripts/markers.py
@@ -27,7 +27,6 @@ markers = [
     ".", "o", "s", "P", "X", "*", "p", "D", "<", ">", "^", "v", ]
 for x, y, marker in zip(X, Y, markers):
     if y == 3: fc = "white"
-    elif y == 2: fc = "None"
     else: fc = "C1"
     plt.scatter(x, 1+y, s=100, marker=marker, fc=fc, ec="C1", lw=0.5)
 


### PR DESCRIPTION
Updates:

- The `make logos` target isn't needed, because there's a copy of the logo already in this repository
- The second line of markers needed it's color setting correctly to show up now in 3.8

Otherwise I've checked the diffs and everything looks fine.

Note that this isn't the most recent release of 3.8 (3.8.4), but 3.8.2, the version that was out when I originally wrote this PR. I think we should just run with this, and I can do a follow up PR soon after to update to 3.9, and then 3.10. Doing it in stages across PRs seems to be the best thing to do to me, instead of trying to do a big jump in one go.