### PR TITLE
Simplify colormap plotting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ check:
 	./check-num-pages.sh handout-tips.pdf 1
 	./check-num-pages.sh handout-beginner.pdf 1
 	./check-num-pages.sh handout-intermediate.pdf 1
-	./check-links.py cheatsheets.pdf
 	./check-diffs.py
+	./check-links.py cheatsheets.pdf
 
 .PHONY: docs
 docs:

--- a/check-links.py
+++ b/check-links.py
@@ -8,12 +8,12 @@ pdf = pdfx.PDFx(sys.argv[1])
 
 refs = [ref for ref in pdf.get_references() if ref.reftype == 'url']
 
-status_codes = list(map(lambda ref: pdfx.downloader.get_status_code(ref.ref), refs))
+status_codes = [pdfx.downloader.get_status_code(ref.ref) for ref in refs]
 
-broken_links = [refs[idx].ref for idx in range(len(refs)) if status_codes[idx] != 200]
+broken_links = [(ref.ref, code) for ref, code in zip(refs, status_codes) if code != 200]
 
 # it seems that Twitter does not respond well to the link checker and throws a 400
-if all(['twitter.com' in url for url in broken_links]):
+if all(['twitter.com' in url for url, _ in broken_links]):
     sys.exit(0)
 else:
     print('Broken links:', broken_links)

--- a/scripts/colormaps.py
+++ b/scripts/colormaps.py
@@ -35,36 +35,14 @@ cmaps = ('viridis', 'plasma', 'inferno', 'magma', 'cividis',
          'terrain', 'ocean', 'gist_earth', 'cubehelix', 'rainbow'
          )
 
-for cmap in cmaps:
-    n = 512
+for name in cmaps:
+    # The maximum number of segments in a cmap is 256, and for anything smaller,
+    # the cmap will map as a suitably discrete set of colours.
+    Z = np.linspace(0, 1, 256).reshape(1, 256)
 
-    if cmap in ['tab10']: n = 10
-    if cmap in ['tab20', 'tab20b', 'tab20c']: n = 20
-    if cmap in ['Pastel1', 'Set1']: n = 9
-    if cmap in ['Pastel2', 'Accent', 'Dark2', 'Set2']: n = 8
-    if cmap in ['Set3']: n = 12
-    if cmap in ['Greys']: n = 11
-    Z = np.linspace(0, 1, n).reshape(1, n)
-
-    ax.imshow(Z, extent=[xmin, xmax, ymin, ymax], cmap=plt.get_cmap(cmap))
+    ax.imshow(Z, extent=[xmin, xmax, ymin, ymax], cmap=name)
     ax.set_xlim(xmin, xmax), ax.set_xticks([])
     ax.set_ylim(ymin, ymax), ax.set_yticks([])
 
-    """
-    if cmap == "tab10":
-        x = np.linspace(xmin, xmax, 11, endpoint=True) + 0.5*(xmax-xmin)/11
-        for i in range(10):
-            ax.text(x[i], (ymin+ymax)/2, "C%d"%i, color="white", zorder=10,
-                    family = "Source Pro Serif", size=10, ha="center", va="center")
-
-    if cmap == "Greys":
-        x = np.linspace(xmin, xmax, 12, endpoint=True) + 0.5*(xmax-xmin)/12
-        for i in range(11):
-            color = "%.1f"%(i/10)
-            text = "%.1f"%(1-i/10)
-            ax.text(x[i], (ymin+ymax)/2, text, color=color, zorder=10,
-                    family = "Source Pro Serif", size=10, ha="center", va="center")
-    """
-
-    fig.savefig(ROOT_DIR / f"figures/colormap-{cmap}.pdf")
+    fig.savefig(ROOT_DIR / f"figures/colormap-{name}.pdf")
     ax.clear()

--- a/scripts/colors.py
+++ b/scripts/colors.py
@@ -33,12 +33,19 @@ palettes = {
 for name, colors in palettes.items():
     C = mpl.colors.to_rgba_array(colors).reshape((1, len(colors), 4))
     ax.imshow(C, extent=[xmin, xmax, ymin, ymax])
+
+    # Drop alpha by assuming we're on a white background PDF.
+    alpha = C[0, :, 3]
+    rgb = C[0, :, :3] * alpha[:, np.newaxis] + (1 - alpha[:, np.newaxis])
+    # Same calculation for luminance as
+    # https://matplotlib.org/stable/users/explain/colors/colors.html#comparison-between-x11-css4-and-xkcd-colors
+    luma = 0.299 * rgb[:, 0] + 0.587 * rgb[:, 1] + 0.114 * rgb[:, 2]
+
     dx = (xmax-xmin)/len(colors)
     for i in range(len(colors)):
-        color = "white"
-        if colors[i] in ['1.0', 'w']: color = "black"
+        text_color = "black" if luma[i] > 0.5 else "white"
         text = str(colors[i]).replace(' ', '')
-        ax.text((i+0.5)*dx, (ymin+ymax)/2, text, color=color, zorder=10,
+        ax.text((i+0.5)*dx, (ymin+ymax)/2, text, color=text_color, zorder=10,
                 family="Source Code Pro", size=9, ha="center", va="center")
 
     fig.savefig(ROOT_DIR / f"figures/colors-{name}.pdf")


### PR DESCRIPTION
All the special cases other than Greys are just the size of the colormap themselves. Also, colormaps are at most 256 elements long, so using `n=512` is probably not necessary.

Also, use the same algorithm as the [Specifying colors tutorial](https://matplotlib.org/stable/users/explain/colors/colors.html#comparison-between-x11-css4-and-xkcd-colors) to choose text colour over colour cycles.