### PR TITLE
Allow binary shapely wheels

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,8 +22,6 @@ jobs:
           sudo apt install \
             fontconfig    \
             imagemagick   \
-            libgeos++-dev \
-            libproj-dev   \
             poppler-utils
           python -m pip install --upgrade pip
           pip install -r requirements/requirements.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,5 +10,3 @@ pip-tools
 pre-commit
 scipy
 sphinx
-
---no-binary shapely

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile requirements.in
 #
---no-binary shapely
-
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.16


### PR DESCRIPTION
A locally-compiled shapely was necessary for older Cartopy that compiled against the same libraries, but it's no longer doing that, so we can use binary Shapely again.