### PR TITLE
Add dependabot config to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This is a copy of the existing config in `matplotlib/matplotlib`, to keep GitHub actions up to date. Currently an old version is preventing the build from running (e.g., see https://github.com/matplotlib/cheatsheets/pull/146).