### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: write
 
 on: [push, pull_request]
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,7 +85,7 @@ jobs:
           STEPS_DIFFS_ARTIFACT_UPLOAD_OUTPUTS_ARTIFACT_URL: ${{ steps.diffs-artifact-upload.outputs.artifact-url }}
       - name: Publish cheatsheets and handouts
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   build:
@@ -18,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -75,8 +79,10 @@ jobs:
       - name: Output artifacts URL
         run: |
           echo 'Artifact URL:' \
-            '${{ steps.diffs-artifact-upload.outputs.artifact-url }}' \
+            '${STEPS_DIFFS_ARTIFACT_UPLOAD_OUTPUTS_ARTIFACT_URL}' \
             >> $GITHUB_STEP_SUMMARY
+        env:
+          STEPS_DIFFS_ARTIFACT_UPLOAD_OUTPUTS_ARTIFACT_URL: ${{ steps.diffs-artifact-upload.outputs.artifact-url }}
       - name: Publish cheatsheets and handouts
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   build:
     runs-on: ubuntu-20.04
     permissions:
@@ -79,7 +79,7 @@ jobs:
             >> $GITHUB_STEP_SUMMARY
       - name: Publish cheatsheets and handouts
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/html/

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ jobs:
     permissions:
       contents: read
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,11 +1,11 @@
 name: CI
-permissions:
-  contents: write
-
 on: [push, pull_request]
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
+
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -13,6 +13,9 @@ jobs:
       - uses: pre-commit/action@v3.0.1
   build:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -76,13 +76,6 @@ jobs:
           name: diffs
           path: |
             diffs/
-      - name: Output artifacts URL
-        run: |
-          echo 'Artifact URL:' \
-            '${STEPS_DIFFS_ARTIFACT_UPLOAD_OUTPUTS_ARTIFACT_URL}' \
-            >> $GITHUB_STEP_SUMMARY
-        env:
-          STEPS_DIFFS_ARTIFACT_UPLOAD_OUTPUTS_ARTIFACT_URL: ${{ steps.diffs-artifact-upload.outputs.artifact-url }}
       - name: Publish cheatsheets and handouts
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.3.0
     hooks:
       - id: flake8


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
