### PR TITLE
Fix cheatsheet publishing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,7 @@ jobs:
           path: |
             diffs/
       - name: Publish cheatsheets and handouts
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should fix https://github.com/matplotlib/cheatsheets/issues/167 - I'm not sure there's any way to tell without merging.