### PR TITLE
Switch Twitter link to BlueSky

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -49,7 +49,7 @@
 
 % --- Fonts -------------------------------------------------------------------
 \usepackage{fontspec}
-\usepackage[fixed]{fontawesome5}
+\usepackage[fixed]{fontawesome6}
 \usepackage[babel=true]{microtype}
 \defaultfontfeatures{Ligatures=TeX}
 \setmainfont{Source Serif Pro}[

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -329,8 +329,8 @@
          {\faIcon{stack-overflow}\,stackoverflow.com/questions/tagged/matplotlib}\\
     \href{https://gitter.im/matplotlib/matplotlib}
          {\faIcon{gitter}\,{https://gitter.im/matplotlib/matplotlib}}\\
-    \href{https://twitter.com/matplotlib}
-         {\faIcon{twitter}\,twitter.com/matplotlib}\\
+    \href{https://bsky.app/profile/matplotlib.org}
+         {\faIcon{bluesky}\,bsky.app/profile/matplotlib.org}\\
     \href{https://mail.python.org/mailman/listinfo/matplotlib-users}
          {\faIcon[regular]{envelope}\,Matplotlib users mailing list}
   \end{myboxed}

--- a/check-links.py
+++ b/check-links.py
@@ -11,10 +11,3 @@ refs = [ref for ref in pdf.get_references() if ref.reftype == 'url']
 status_codes = [pdfx.downloader.get_status_code(ref.ref) for ref in refs]
 
 broken_links = [(ref.ref, code) for ref, code in zip(refs, status_codes) if code != 200]
-
-# it seems that Twitter does not respond well to the link checker and throws a 400
-if all(['twitter.com' in url for url, _ in broken_links]):
-    sys.exit(0)
-else:
-    print('Broken links:', broken_links)
-    sys.exit(1)


### PR DESCRIPTION
Two reasons for swapping:

- Twitter/X doesn't play well with the linkchecker (I'm hoping BlueSky does)
- BlueSky provides a better experience for non-logged in users compared to Twitter/X