### PR TITLE
Remove example of small-caps font

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Beginner handout [(download pdf)](https://matplotlib.org/cheatsheets/handout-beg
                                 or https://github.com/adobe-fonts/source-sans-pro/tree/release/OTF
 * `fonts/source-serif-pro/*` : See https://fonts.google.com/specimen/Source+Serif+Pro
                                 or https://github.com/adobe-fonts/source-serif-pro/tree/release/OTF
-* `fonts/eb-garamond/*`      : See https://bitbucket.org/georgd/eb-garamond/src/master
 * `fonts/pacifico/*`         : See https://fonts.google.com/download?family=Pacifico
 
 On Linux, with `make` installed, the fonts can be set up with the following command:

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -522,7 +522,7 @@
   \scale{projection-3d.pdf}
       {p='3d'\hfill\api{https://matplotlib.org/stable/api/toolkits/mplot3d.html}}{}
   \plot{projection-cartopy.pdf}{p=ccrs.Orthographic()}
-       {https://scitools.org.uk/cartopy/docs/latest/reference/projections.html}
+       {https://cartopy.readthedocs.io/stable/reference/projections.html}
        {import cartopy.crs as ccrs}
        {}
   \end{myboxed}

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -327,7 +327,7 @@
          {\faIcon{discourse}\,discourse.matplotlib.org}\\
     \href{https://stackoverflow.com/questions/tagged/matplotlib}
          {\faIcon{stack-overflow}\,stackoverflow.com/questions/tagged/matplotlib}\\
-    \href{https://gitter.im/matplotlib/matplotlib}
+    \href{https://app.gitter.im/#/room/#matplotlib_matplotlib:gitter.im}
          {\faIcon{gitter}\,{https://gitter.im/matplotlib/matplotlib}}\\
     \href{https://twitter.com/matplotlib}
          {\faIcon{twitter}\,twitter.com/matplotlib}\\

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -327,8 +327,6 @@
          {\faIcon{discourse}\,discourse.matplotlib.org}\\
     \href{https://stackoverflow.com/questions/tagged/matplotlib}
          {\faIcon{stack-overflow}\,stackoverflow.com/questions/tagged/matplotlib}\\
-    \href{https://app.gitter.im/#/room/#matplotlib_matplotlib:gitter.im}
-         {\faIcon{gitter}\,{gitter.im/matplotlib/matplotlib}}\\
     \href{https://twitter.com/matplotlib}
          {\faIcon{twitter}\,twitter.com/matplotlib}\\
     \href{https://mail.python.org/mailman/listinfo/matplotlib-users}

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -328,7 +328,7 @@
     \href{https://stackoverflow.com/questions/tagged/matplotlib}
          {\faIcon{stack-overflow}\,stackoverflow.com/questions/tagged/matplotlib}\\
     \href{https://app.gitter.im/#/room/#matplotlib_matplotlib:gitter.im}
-         {\faIcon{gitter}\,{https://gitter.im/matplotlib/matplotlib}}\\
+         {\faIcon{gitter}\,{gitter.im/matplotlib/matplotlib}}\\
     \href{https://twitter.com/matplotlib}
          {\faIcon{twitter}\,twitter.com/matplotlib}\\
     \href{https://mail.python.org/mailman/listinfo/matplotlib-users}

--- a/check-links.py
+++ b/check-links.py
@@ -11,9 +11,10 @@ refs = [ref for ref in pdf.get_references() if ref.reftype == 'url']
 status_codes = [pdfx.downloader.get_status_code(ref.ref) for ref in refs]
 
 broken_links = [(ref.ref, code) for ref, code in zip(refs, status_codes) if code != 200]
+# It seems that Twitter and stackoverflow do not respond well to the link checker and throws a 400
+broken_links = [b for b in broken_links if not ('twitter.com' in b or 'stackoverflow.com' in b)]
 
-# it seems that Twitter does not respond well to the link checker and throws a 400
-if all(['twitter.com' in url for url, _ in broken_links]):
+if len(broken_links) == 0:
     sys.exit(0)
 else:
     print('Broken links:', broken_links)

--- a/check-links.py
+++ b/check-links.py
@@ -12,7 +12,7 @@ status_codes = [pdfx.downloader.get_status_code(ref.ref) for ref in refs]
 
 broken_links = [(ref.ref, code) for ref, code in zip(refs, status_codes) if code != 200]
 # It seems that Twitter and stackoverflow do not respond well to the link checker and throws a 400
-broken_links = [b for b in broken_links if not ('twitter.com' in b or 'stackoverflow.com' in b)]
+broken_links = [b for b in broken_links if not ('twitter.com' in b[0] or 'stackoverflow.com' in b[0])]
 
 if len(broken_links) == 0:
     sys.exit(0)

--- a/fonts/Makefile
+++ b/fonts/Makefile
@@ -1,6 +1,5 @@
-FONT_DIRS := eb-garamond roboto roboto-mono roboto-slab source-code-pro source-sans-pro source-serif-pro pacifico
+FONT_DIRS := roboto roboto-mono roboto-slab source-code-pro source-sans-pro source-serif-pro pacifico
 
-EB_GARAMOND_ZIP      := https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-0.016.zip
 ROBOTO_ZIP           := https://github.com/googlefonts/roboto/releases/download/v2.138/roboto-unhinted.zip
 ROBOTO_MONO_ZIP      := https://github.com/googlefonts/RobotoMono/archive/8f651634e746da6df6c2c0be73255721d24f2372.zip
 ROBOTO_SLAB_ZIP      := https://github.com/googlefonts/robotoslab/archive/a65e6d00d8e3e7ee2fabef844e58fa12690384d2.zip
@@ -18,7 +17,6 @@ default: all
 .PHONY: all
 all: sources
 	mkdir -p $(FONT_DIRS)
-	cd eb-garamond && unzip -j /tmp/eb-garamond.zip "EBGaramond-0.016/otf/*.otf" $(UNZIP_FLAGS)
 	cd roboto && unzip -j /tmp/roboto.zip "*.ttf" $(UNZIP_FLAGS)
 	cd roboto-mono && unzip -j /tmp/roboto-mono.zip "RobotoMono-8f651634e746da6df6c2c0be73255721d24f2372/fonts/ttf/*.ttf" $(UNZIP_FLAGS)
 	cd roboto-slab && unzip -j /tmp/roboto-slab.zip "robotoslab-a65e6d00d8e3e7ee2fabef844e58fa12690384d2/fonts/static/*.ttf" $(UNZIP_FLAGS)
@@ -29,7 +27,6 @@ all: sources
 
 .PHONY: sources
 sources:
-	wget $(EB_GARAMOND_ZIP) -O /tmp/eb-garamond.zip
 	wget $(ROBOTO_ZIP) -O /tmp/roboto.zip
 	wget $(ROBOTO_MONO_ZIP) -O /tmp/roboto-mono.zip
 	wget $(ROBOTO_SLAB_ZIP) -O /tmp/roboto-slab.zip

--- a/scripts/fonts.py
+++ b/scripts/fonts.py
@@ -11,25 +11,9 @@ ROOT_DIR = pathlib.Path(__file__).parent.parent
 
 fig = plt.figure(figsize=(4.25, 3.8))
 ax = fig.add_axes([0, 0, 1, 1], frameon=False, xticks=[], yticks=[],
-                  xlim=[0, 40], ylim=[0, 38])
+                  xlim=[0, 40], ylim=[0, 34])
 
 y = 1
-
-# -----------------------------------------------------------------------------
-variants = {
-    "normal" : "../fonts/eb-garamond/EBGaramond08-Regular.otf",
-    "small-caps" : "../fonts/eb-garamond/EBGaramondSC08-Regular.otf"
-}
-
-text = "The quick brown fox jumps over the lazy dog"
-for i, (variant, file) in enumerate(variants.items()):
-    ax.text(1, y, text, size=9, va="center", font=pathlib.Path(file).resolve())
-
-    ax.text(39, y, variant,
-            color="0.25", va="center", ha="right",
-            size="small", family="Source Code Pro", weight=400)
-    y += 1.65
-y += 1
 
 # -----------------------------------------------------------------------------
 styles = ["normal", "italic"]


### PR DESCRIPTION
For a while downloading the font for this example has been failing. I then realised that the code here isn't actually using Matplotlib to specifcially request a small caps font, it's just plotting in a font that is already small caps:

```python
ax.text(1, y, text, size=9, va="center", font=pathlib.Path(file).resolve())
```

Some brief searching suggests small caps fonts are rare, and thus I think this is a niche enough case that dropping this is okay.