### PR TITLE
Improve contrast between optional argument text and background

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -149,7 +149,7 @@
 }
 
 
-\newcommand{\optional}[1]{\textcolor{gray}{#1}}
+\newcommand{\optional}[1]{\textcolor[RGB]{78, 78, 78}{#1}}
 \newcommand{\mandatory}[1]{\textbf{#1}}
 \newcommand{\parameter}[2]{%
   \expandafter\ifstrequal\expandafter{#1}{optional}%

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -149,7 +149,8 @@
 }
 
 
-\newcommand{\optional}[1]{\textcolor[RGB]{78, 78, 78}{#1}}
+# 89, 89, 89 is the lightest colour that still gives a good contrast ratio with the white background
+\newcommand{\optional}[1]{\textcolor[RGB]{89, 89, 89}{#1}}
 \newcommand{\mandatory}[1]{\textbf{#1}}
 \newcommand{\parameter}[2]{%
   \expandafter\ifstrequal\expandafter{#1}{optional}%

--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -149,7 +149,7 @@
 }
 
 
-# 89, 89, 89 is the lightest colour that still gives a good contrast ratio with the white background
+% 89, 89, 89 is the lightest colour that still gives a good contrast ratio with the white background
 \newcommand{\optional}[1]{\textcolor[RGB]{89, 89, 89}{#1}}
 \newcommand{\mandatory}[1]{\textbf{#1}}
 \newcommand{\parameter}[2]{%


### PR DESCRIPTION
Fixes https://github.com/matplotlib/cheatsheets/issues/138 (I think). To choose the colour I used https://webaim.org/resources/contrastchecker/ to pick the lightest colour that still passes the accessibility checks (which seem to be a contrast ratio of at least 7:1)