### PR TITLE
Fix argument order in errorbar() (fixes #199)

### DIFF
--- a/cheatsheets.tex
+++ b/cheatsheets.tex
@@ -442,12 +442,12 @@
        \optional{bootstrap},
        \optional{widths} }
      {}
-  \plot{advanced-errorbar.pdf}{\textbf{errorbar}(X,Y,xerr,yerr, …)}
+  \plot{advanced-errorbar.pdf}{\textbf{errorbar}(X,Y,yerr,xerr, …)}
      {https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.errorbar.html}
      { \mandatory{X},
        \mandatory{Y},
-       \optional{xerr},
        \optional{yerr},
+       \optional{xerr},
        \optional{fmt} }
      {}
   \plot{advanced-hist.pdf}{\textbf{hist}(X, bins, …)}


### PR DESCRIPTION
errorbar() xerr/yerr arguments were swapped in the cheat sheet, compared to the method's actual signature